### PR TITLE
compile.sh and requiredPackages.sh modification

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -2,7 +2,7 @@
 
 compile_and_link ()
 {
-	g++ -g $1 -o $2 `pkg-config --cflags --libs gtk+-3.0 opencv`
+	g++ -std=c++11 -g $1 -o $2 `pkg-config --cflags --libs gtk+-3.0 opencv`
 }
 
 

--- a/requiredPackages.sh
+++ b/requiredPackages.sh
@@ -1,16 +1,29 @@
 #!/bin/bash
 
-#installing OpenCV requirements , links : https://docs.opencv.org/master/d7/d9f/tutorial_linux_install.html
-sudo apt-get install build-essential cmake git libgtk2.0-dev libgtk-3-0 libgtk-3-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev git
+# check if root access provided by user
+if [ "$EUID" -ne 0 ]; then
+    echo "This bash file will install some required packages on your device. Please provide root access by executing \"sudo ./requiredPackages.sh\"."
+    exit
+fi
 
+echo "Do you want to install some optional packages too? (yes/no) "
+read install_optional_packages
+
+# determine required packages to be installed
+packages=""
+if (( $install_optional_packages == "yes" )); then
+    $packages="cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev"
+else
+    $packages="cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev"
+fi
+
+# If you are interested in openCV installation process you may want to visit: https://docs.opencv.org/master/d7/d9f/tutorial_linux_install.html
 #clone OpenCV from git
 git clone https://github.com/opencv/opencv.git
 cd opencv
 mkdir build
 cd build
-
-#compiling git
 cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=/usr/local ..
-make -j $(nproc)
+make -j7 # runs 7 jobs in parallel
 sudo make install
 

--- a/requiredPackages.sh
+++ b/requiredPackages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# check if root access provided by user
+# check if root access is provided by user
 if [ "$EUID" -ne 0 ]; then
     echo "This bash file will install some required packages on your device. Please provide root access by executing \"sudo ./requiredPackages.sh\"."
     exit
@@ -18,7 +18,7 @@ else
 fi
 
 # If you are interested in openCV installation process you may want to visit: https://docs.opencv.org/master/d7/d9f/tutorial_linux_install.html
-#clone OpenCV from git
+# clone OpenCV from git
 git clone https://github.com/opencv/opencv.git
 cd opencv
 mkdir build


### PR DESCRIPTION
## RequiredPackages.sh
_requiredPackages.sh_ modifications will result in providing an easy (or easier) way **to make environment ready** for compilation process. Within the main branch  (@Strongsaxophone 
 /videoPlayer) all optional packages suggested by OpenCV installation doc will install on device without asking or promting user about it. Also It seems there is a mistake in commenting here:
```
#compiling git
cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=/usr/local ..
make -j $(nproc)
sudo make install
```
It's making (and installing) OpenCV not git. 
And consider making all available processing units busy by using ```nproc``` might not be a wise decision. Because it may results in some delays if user needs to simultaneously make some actions on OS.  

## compile.sh
As I've tried to compile sources (using _compile.sh_), I got an error implying c++ 2011 implementation is required to use openCV libraries.